### PR TITLE
Add enum, union support

### DIFF
--- a/xml/test_definition_file.xml
+++ b/xml/test_definition_file.xml
@@ -14,6 +14,10 @@
       <arg name="nodeRemoved" type="(so)"/>
     </signal>
 
+    <signal name="U32AsEnum">
+        <arg name="my_type" type="u"/>
+    </signal>
+
     <method name="RequestName">
       <arg direction="in" name="apple" type="s"/>
       <arg direction="in" name="orange" type="u"/>

--- a/zbus-lockstep-macros/src/lib.rs
+++ b/zbus-lockstep-macros/src/lib.rs
@@ -85,7 +85,11 @@ use syn::{parse::ParseStream, parse_macro_input, DeriveInput, Ident, LitStr, Tok
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```rust
+/// use zvariant::OwnedObjectPath;
+/// use zbus_lockstep_macros::validate;
+/// use zvariant::Type;
+///
 /// #[validate(xml: "xml", interface: "org.example.Node", signal: "RemoveNode")]
 /// #[derive(Type)]
 /// struct RemoveNodeSignal {

--- a/zbus-lockstep-macros/tests/validate.rs
+++ b/zbus-lockstep-macros/tests/validate.rs
@@ -5,6 +5,17 @@ use zbus_lockstep_macros::validate;
 use zvariant::{OwnedObjectPath, Type};
 
 #[test]
+fn test_validate_enum() {
+    #[validate(signal: "U32AsEnum")]
+    #[derive(Debug, Type)]
+    enum NodeTypes {
+        _Option1,
+        _Option2,
+    }
+    test_NodeTypes_type_signature();
+}
+
+#[test]
 fn test_validate_macro_node_add_path_as_env_variable() {
     // set env variable to enable validation
     std::env::set_var("LOCKSTEP_XML_PATH", "./xml");


### PR DESCRIPTION
Adds support for `enum` and `union` types by genericizing the `#[validate]` macro.
